### PR TITLE
adding test to Switch method to make sure existing buffer points to an existing file, in case the file is moved while vim is open

### DIFF
--- a/autoload/goto_header.vim
+++ b/autoload/goto_header.vim
@@ -177,7 +177,7 @@ function! goto_header#Switch()
     endfor
     if found
         let buf_exist = bufnr(filename)
-        if buf_exist == -1
+        if buf_exist == -1 || !filereadable(bufname(filename))
             let info_find = s:GetFindResult(filename)
             call s:DisplayPrompt(info_find, filename)
         else


### PR DESCRIPTION
Hello,

This change means to fix the following minor issue:

If i run vim then open:
src/foo.c
src/foo.h
then rename the src folder src_new (using mv or nerdtree for example) while vim is open,
re-oppening foo.c (now at path src_new/foo.c) and using the GotoHeaderSwitch method redirect to the (now empty but still existing) buffer oppened at src/foo.h instead of opening src_new/foo.h.
