### PR TITLE
Add support for Windows

### DIFF
--- a/plugin/goto_header.vim
+++ b/plugin/goto_header.vim
@@ -7,11 +7,14 @@ if exists('g:goto_header_loadded')
 endif
 let g:goto_header_loadded = 1
 
+let which_fd = system('which fd')[0]
+let which_fdfind = system('which fdfind')[0]
+
 " check fd binary name (needed because it's called fdfdind on ubuntu)
 " Then check if it's installed
-if system('which fd')[0] ==# '/'
+if (which_fd ==# '/' || which_fd ==#'C')
     let g:goto_header_fd_binary_name = 'fd'
-elseif system('which fdfind')[0] ==# '/'
+elseif (which_fdfind ==# '/' || which_fdfind ==#'C')
     let g:goto_header_fd_binary_name = 'fdfind'
 else
     echoerr "fd not found, please install it"


### PR DESCRIPTION
On Windows you can install `which`, but the paths start with the drive letter which is most commonly C:

In order for this plugin to work you need to have `fd` and `which` installed somewhere in drive C:\ and add them to $PATH